### PR TITLE
Add initial Travis-CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: perl
+
+perl:
+    - "5.26"
+    - "5.24"
+    - "5.22"
+    - "5.20"
+    - "5.18"
+    - "5.16"
+    - "5.14"
+    - "5.12"
+    - "5.10"
+
+before_install:
+    - echo "user DUMMYUSER" > ~/.pause
+
+install:
+    - cpanm Test::Output || { cat ~/.cpanm/build.log ; false ; }
+    - dzil authordeps --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
+    - dzil listdeps --author --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
+
+sudo: false
+
+script:
+    - dzil test --author --release


### PR DESCRIPTION
Hi Sawyer!

Here's an initial Travis config for `Module::Version`.  You'll notice that the tests *fail* when run with this configuration; that's because of the bug in the test suite that the next patch fixes (I just wanted to get Travis-CI up and running first).  I noticed this while working on my CPANPRC project for this month and `Module::Version` happened to be the only dep that didn't install and test correctly.  Note that `Test::Output` doesn't seem to be a dependency necessary for running the tests and this is possibly a reason why the bug fell through the cracks, and possibly why there are lots of passes on cpantesters, but also several failures.  Anyway, I noticed the issue and will submit a patch in the coming minutes. :-)