### PR TITLE
Remove hardcoded Test::More version number in tests

### DIFF
--- a/t/app.t
+++ b/t/app.t
@@ -43,8 +43,6 @@ my $run = sub { $app->run() };
     # check run() without input
     $app->{'modules'} = ['Test::More'];
     my $ver = $Test::More::VERSION;
-    $ver = '1.3021350';
-    $ver =~ s/0+$//;
     stdout_is( $run, "$ver\n", 'run() ok - regular' );
 }
 


### PR DESCRIPTION
The app being tested here has `Test::More` as its module, however the
version number for `Test::More` gets overridden and this isn't the
version number that appears on all systems.  By removing the hardcoded
value, the test should now be generic again and able to pass on systems
with other `Test::More` versions.