### PR TITLE
Require Test::Output

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -5,3 +5,4 @@ requires 'ExtUtils::MakeMaker' => '6.56';
 requires 'Getopt::Long';
 
 test_requires 'Test::More';
+test_requires 'Test::Output';


### PR DESCRIPTION
... so that all tests can be run in the test suite.

This would then render the `cpanm Test::Output` line in the Travis config obsolete.  If you want me to add that change into this PR, just let me know and I'll update this PR and resubmit.