### PR TITLE
the version of Test::More was nailed at 1.3021350

### DIFF
--- a/t/app.t
+++ b/t/app.t
@@ -43,7 +43,6 @@ my $run = sub { $app->run() };
     # check run() without input
     $app->{'modules'} = ['Test::More'];
     my $ver = $Test::More::VERSION;
-    $ver = '1.3021350';
     $ver =~ s/0+$//;
     stdout_is( $run, "$ver\n", 'run() ok - regular' );
 }


### PR DESCRIPTION
... and it makes the test fail for any system where Test::More is at a different version.